### PR TITLE
Fix 1.1.0 version and tests

### DIFF
--- a/aiobreaker/version.py
+++ b/aiobreaker/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 """The current version."""
 
 short_version = ".".join(__version__.split(".")[:2])

--- a/test/test_circuit_async.py
+++ b/test/test_circuit_async.py
@@ -139,7 +139,7 @@ async def test_successful_after_wait(storage, delta):
     try:
         await breaker.call_async(func_exception_async)
     except CircuitBreakerError as e:
-        await asyncio.sleep(e.time_remaining.total_seconds())
+        await asyncio.sleep(delta.total_seconds())
 
     await breaker.call_async(func_succeed_async)
     assert func_succeed_async.call_count == 1


### PR DESCRIPTION
Minimal changes for my first PR.

1. Bump version to 1.1.0. Latest version I could find on PYPI is 1.0.0, which still had the mutex/lock which is already removed on latest master branch. May need to publish a new version to PYPI, if everything looks fine.

2. Use the delta variable fixture for a more fixed asyncio.sleep timing. This will allow the timeout to complete and will close the circuit. Although anything integer greater or equal to 1 should work the same.

Feel free to comment on anything. Thanks!