### PR TITLE
Fix typing on listener

### DIFF
--- a/aiobreaker/listener.py
+++ b/aiobreaker/listener.py
@@ -28,7 +28,7 @@ class CircuitBreakerListener:
         Called when a function executed over the circuit breaker 'breaker' succeeds.
         """
 
-    def state_change(self, breaker: 'CircuitBreaker', old: 'CircuitBreakerState', new: 'CircuitBreakerState') -> None:
+    def state_change(self, breaker: 'CircuitBreaker', old: 'CircuitBreakerBaseState', new: 'CircuitBreakerBaseState') -> None:
         """
         Called when the state of the circuit breaker 'breaker' changes.
         """


### PR DESCRIPTION
I am currently implementing a listener of the circuitbreaker, but actually, received object does not match the declared typed.


https://github.com/mardiros/blacksmith/blob/master/src/blacksmith/middleware/circuit_breaker.py#L48-L66
